### PR TITLE
Add import root in .deepsource.toml

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -16,6 +16,7 @@ enabled = true
 
   [analyzers.meta]
   import_paths = ["github.com/malusev998/malusev998/server"]
+  import_root = "github.com/malusev998/malusev998/"
 
 [[analyzers]]
 name = "javascript"


### PR DESCRIPTION
When the import path is not the same as the root of the repository, DeepSource expects an import root. Docs: https://deepsource.io/docs/analyzer/go.html#import-root